### PR TITLE
Fix code scanning alert no. 24: Resource injection

### DIFF
--- a/WebGoat/App_Code/DB/SqliteDbProvider.cs
+++ b/WebGoat/App_Code/DB/SqliteDbProvider.cs
@@ -21,7 +21,10 @@ namespace OWASP.WebGoat.NET.App_Code.DB
 
         public SqliteDbProvider(ConfigFile configFile)
         {
-            _connectionString = string.Format("Data Source={0};Version=3", configFile.Get(DbConstants.KEY_FILE_NAME));
+            var builder = new SqliteConnectionStringBuilder();
+            builder.DataSource = configFile.Get(DbConstants.KEY_FILE_NAME);
+            builder.Version = 3;
+            _connectionString = builder.ConnectionString;
 
             _clientExec = configFile.Get(DbConstants.KEY_CLIENT_EXEC);
             _dbFileName = configFile.Get(DbConstants.KEY_FILE_NAME);


### PR DESCRIPTION
Fixes [https://github.com/lorrainetansz/ghas-demo-csharp/security/code-scanning/24](https://github.com/lorrainetansz/ghas-demo-csharp/security/code-scanning/24)

To fix the problem, we should use a connection string builder class to construct the connection string safely. This approach ensures that user input is properly escaped and does not alter the meaning of the connection string. Specifically, we will use the `SqliteConnectionStringBuilder` class to construct the connection string.

1. Replace the direct string concatenation with the `SqliteConnectionStringBuilder` to construct the connection string.
2. Ensure that the `SqliteConnectionStringBuilder` is used to set the `DataSource` property with the user-provided input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
